### PR TITLE
Vers 8 now requieres the root user to be specified or it will default…

### DIFF
--- a/manifests/forwarder/service/nix.pp
+++ b/manifests/forwarder/service/nix.pp
@@ -19,7 +19,7 @@ class splunk::forwarder::service::nix inherits splunk::forwarder::service {
       notify  => Exec['enable_splunkforwarder'],
     }
     if $splunk::params::supports_systemd and $splunk::forwarder::splunk_user == 'root' {
-      $user_args = ''
+      $user_args = '-user root -group root'
     } else {
       $user_args = "-user ${splunk::forwarder::splunk_user}"
     }


### PR DESCRIPTION
Correcting issue where the splunkforwarder will still configure it's unit file to run as splunk even if you specify the root user.